### PR TITLE
fix: 楽観追加した自分の新規 PD に正しい @ハンドル/プロフィールリンクを出す

### DIFF
--- a/apps/frontend/src/feature/pd/utils/build-created-pd.test.ts
+++ b/apps/frontend/src/feature/pd/utils/build-created-pd.test.ts
@@ -22,6 +22,7 @@ const aUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
   lastName: "User",
   fullName: "Dev User",
   imageUrl: "https://example.com/me.png",
+  userName: "taro",
   ...overrides,
 });
 
@@ -40,6 +41,15 @@ describe("作成したPDを詳細化する", () => {
       userFullName: "森 太郎",
       imageUrl: "https://example.com/a.png",
     });
+  });
+
+  test("投稿者のハンドルを現在のユーザーのもので埋める", () => {
+    const result = 作成したPDを詳細化する({
+      created: aCreatedPd(),
+      user: aUser({ userName: "morimori" }),
+    });
+
+    expect(result.userDetail.userName).toBe("morimori");
   });
 
   test("フルネームが無いときは姓名を結合した表示名にする", () => {

--- a/apps/frontend/src/feature/pd/utils/build-created-pd.ts
+++ b/apps/frontend/src/feature/pd/utils/build-created-pd.ts
@@ -17,7 +17,7 @@ export const 作成したPDを詳細化する = ({
       id: user?.id ?? created.userId,
       userFullName,
       imageUrl: user?.imageUrl ?? "",
-      userName: "",
+      userName: user?.userName ?? "",
     },
     likeUserNames: [],
     likeUsers: [],

--- a/apps/frontend/src/lib/auth/mock-user.ts
+++ b/apps/frontend/src/lib/auth/mock-user.ts
@@ -8,4 +8,5 @@ export const MOCK_USER: AuthUser = {
   lastName: "User",
   fullName: "Dev User",
   imageUrl: "",
+  userName: "taro",
 };

--- a/apps/frontend/src/lib/auth/types.ts
+++ b/apps/frontend/src/lib/auth/types.ts
@@ -4,6 +4,7 @@ export interface AuthUser {
   readonly lastName: string | null;
   readonly fullName: string | null;
   readonly imageUrl: string;
+  readonly userName: string | null;
 }
 
 export type SignInResult = { error: unknown };

--- a/apps/frontend/src/lib/auth/use-current-user.ts
+++ b/apps/frontend/src/lib/auth/use-current-user.ts
@@ -11,7 +11,19 @@ const useMockCurrentUser = (): { user: AuthUser | null } => ({
 
 const useClerkCurrentUser = (): { user: AuthUser | null } => {
   const { user } = useClerkUser();
-  return { user: user ?? null };
+  if (!user) {
+    return { user: null };
+  }
+  return {
+    user: {
+      id: user.id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      fullName: user.fullName,
+      imageUrl: user.imageUrl,
+      userName: user.username,
+    },
+  };
 };
 
 export const useCurrentUser = AUTH_MOCKING

--- a/apps/frontend/src/lib/orval-fetcher.ts
+++ b/apps/frontend/src/lib/orval-fetcher.ts
@@ -93,7 +93,6 @@ export const orvalFetch = async <T>(
   const res = await fetch(`${API_URL}${path}`, {
     ...options,
     headers,
-    cache: path.includes("/image/") ? "default" : "no-store",
   });
 
   return handleOrvalResponse<T>(res);


### PR DESCRIPTION
投稿直後に楽観追加する PD の投稿者ハンドルが空で、次の再取得まで @ハンドルと
プロフィールリンクが出なかった。AuthUser に userName を追加し、Clerk の
user.username をマップ・MOCK_USER にも付与して、build-created-pd が現在ユーザーの ハンドルで詳細化するようにした。PdAuthor のハンドル空ガードは list 側の null
ハンドル保険として維持。

あわせて、誤診（ブラウザキャッシュ説）の名残で冗長だった orval-fetch の
cache: "no-store" を撤去。キャッシュ制御はサーバの Cache-Control に集約する。