### PR TITLE
feat: プロフィール(表示名/ID/画像)変更を全画面へ即時反映する

### DIFF
--- a/apps/frontend/src/feature/profile/components/profile-view.tsx
+++ b/apps/frontend/src/feature/profile/components/profile-view.tsx
@@ -4,11 +4,9 @@ import { Card, CardContent, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCurrentUser } from "@/lib/auth/use-current-user";
-import {
-  useUpdateProfileHandle,
-  useUpdateProfileName,
-  useUpdateProfilePicture,
-} from "@/lib/auth/use-update-profile";
+import { useUpdateProfileHandle } from "../hooks/use-update-profile-handle";
+import { useUpdateProfileName } from "../hooks/use-update-profile-name";
+import { useUpdateProfilePicture } from "../hooks/use-update-profile-picture";
 import { ProfileHandleField } from "./profile-handle-field";
 import { ProfileNameField } from "./profile-name-field";
 import { ProfilePictureField } from "./profile-picture-field";

--- a/apps/frontend/src/feature/profile/hooks/use-refresh-user-display.ts
+++ b/apps/frontend/src/feature/profile/hooks/use-refresh-user-display.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { userDisplayQueryKeys } from "./user-display-query-keys";
+
+export const useRefreshUserDisplay = (): (() => Promise<void>) => {
+  const queryClient = useQueryClient();
+
+  return async () => {
+    await Promise.all(
+      userDisplayQueryKeys().map((queryKey) =>
+        queryClient.invalidateQueries({ queryKey }),
+      ),
+    );
+  };
+};

--- a/apps/frontend/src/feature/profile/hooks/use-update-profile-handle.ts
+++ b/apps/frontend/src/feature/profile/hooks/use-update-profile-handle.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import {
+  type UpdateProfileHandle,
+  useUpdateProfileHandle as useAuthUpdateProfileHandle,
+} from "@/lib/auth/use-update-profile";
+import { useRefreshUserDisplay } from "./use-refresh-user-display";
+
+export const useUpdateProfileHandle = (): UpdateProfileHandle => {
+  const { updateProfileHandle } = useAuthUpdateProfileHandle();
+  const refreshUserDisplay = useRefreshUserDisplay();
+
+  return {
+    updateProfileHandle: async (handle) => {
+      const result = await updateProfileHandle(handle);
+      if (result.ok) {
+        await refreshUserDisplay();
+      }
+      return result;
+    },
+  };
+};

--- a/apps/frontend/src/feature/profile/hooks/use-update-profile-name.ts
+++ b/apps/frontend/src/feature/profile/hooks/use-update-profile-name.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import {
+  type UpdateProfileName,
+  useUpdateProfileName as useAuthUpdateProfileName,
+} from "@/lib/auth/use-update-profile";
+import { useRefreshUserDisplay } from "./use-refresh-user-display";
+
+export const useUpdateProfileName = (): UpdateProfileName => {
+  const { updateProfileName } = useAuthUpdateProfileName();
+  const refreshUserDisplay = useRefreshUserDisplay();
+
+  return {
+    updateProfileName: async (input) => {
+      await updateProfileName(input);
+      await refreshUserDisplay();
+    },
+  };
+};

--- a/apps/frontend/src/feature/profile/hooks/use-update-profile-picture.ts
+++ b/apps/frontend/src/feature/profile/hooks/use-update-profile-picture.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import {
+  type UpdateProfilePicture,
+  useUpdateProfilePicture as useAuthUpdateProfilePicture,
+} from "@/lib/auth/use-update-profile";
+import { useRefreshUserDisplay } from "./use-refresh-user-display";
+
+export const useUpdateProfilePicture = (): UpdateProfilePicture => {
+  const { updateProfilePicture } = useAuthUpdateProfilePicture();
+  const refreshUserDisplay = useRefreshUserDisplay();
+
+  return {
+    updateProfilePicture: async (file) => {
+      await updateProfilePicture(file);
+      await refreshUserDisplay();
+    },
+  };
+};

--- a/apps/frontend/src/feature/profile/hooks/user-display-query-keys.test.ts
+++ b/apps/frontend/src/feature/profile/hooks/user-display-query-keys.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { userDisplayQueryKeys } from "./user-display-query-keys";
+
+const prefixes = () => userDisplayQueryKeys().map((queryKey) => queryKey[0]);
+
+describe("プロフィール変更後に再取得すべきクエリの決定", () => {
+  it("PD 一覧・タイムラインの表示を再取得対象に含める", () => {
+    expect(prefixes()).toContain("/pd");
+  });
+
+  it("RePd といいねの表示を再取得対象に含める", () => {
+    expect(prefixes()).toContain("/repd");
+  });
+
+  it("週次の貢献統計の表示を再取得対象に含める", () => {
+    expect(prefixes()).toContain("/pd/stats/weekly");
+  });
+
+  it("通知の行為者の表示を再取得対象に含める", () => {
+    expect(prefixes()).toContain("/notifications");
+  });
+});

--- a/apps/frontend/src/feature/profile/hooks/user-display-query-keys.ts
+++ b/apps/frontend/src/feature/profile/hooks/user-display-query-keys.ts
@@ -1,0 +1,16 @@
+import type { QueryKey } from "@tanstack/react-query";
+import {
+  pdRootQueryKey,
+  weeklyStatsQueryKey,
+} from "@/feature/pd/api/query-keys";
+import {
+  getFetchNotificationsQueryKey,
+  getFetchRePdsQueryKey,
+} from "@/schema/api";
+
+export const userDisplayQueryKeys = (): readonly QueryKey[] => [
+  pdRootQueryKey(),
+  getFetchRePdsQueryKey(),
+  weeklyStatsQueryKey(),
+  getFetchNotificationsQueryKey(),
+];


### PR DESCRIPTION
## 背景

PR #355（ID(@handle) 変更フォーム）で、handle 変更後にタイムライン等の @ハンドル表示が旧値のまま残る問題が `/code-review` で挙がっていた。#355 が invalidate 対応を入れる前にマージされたため、その対応をこの PR で入れ直し、さらに **表示名・画像**にも同じ即時反映を適用する。

## 何を直すか

プロフィール編集で **表示名・ID(@handle)・画像** を変更しても、他ユーザー向けに表示される値（タイムライン/PD詳細/RePd/いいね/週次統計/通知に出る表示名・@ハンドル・アバター）が旧値のまま残り、リロードするまで更新されない問題を解消する。

## 仕組み

表示名(`firstName`/`lastName`)・`userName`・`imageUrl` はすべて**同一の `UserDetail` ペイロード**に同居し、各クエリ内で `/user/details` を join して埋めている（PD一覧のレスポンス自体には `userId` しか無い）。そのため join 元の **4 系統**を invalidate すれば 3 フィールドとも即時反映される（プレフィックス一致で詳細キーも網羅）:

- `/pd`（タイムライン・PD詳細・いいね・ユーザータイムライン）
- `/repd`（RePd・RePdいいね）
- `/pd/stats/weekly`（週次貢献ランキング）
- `/notifications`（通知の行為者名）

自分自身のプロフィール画面表示は Clerk を直接読む（React Query 非経由）ため、`user.update()` の反映で自動更新され invalidate 対象外。

## 設計

- Clerk 抽象レイヤ (`lib/auth/use-update-profile.ts`) は **React Query 非依存のまま**保つ
- profile feature に「更新成功後に再取得する facade フック」を新設（既存の mutation フックと同じく invalidate は hooks 層に置く）
  - `user-display-query-keys.ts`: 再取得対象キーの決定（純関数）+ テスト
  - `use-refresh-user-display.ts`: 4 系統を invalidate する共通処理
  - `use-update-profile-{name,handle,picture}.ts`: 各更新 + 成功後に `useRefreshUserDisplay()` を呼ぶ facade
- ID の facade は `Result` を返すので `result.ok` 判定後に invalidate。表示名/画像は失敗時に throw するので await 成功後にのみ invalidate が走る。

## 変更ファイル

- `feature/profile/hooks/user-display-query-keys.ts` (新規) + `.test.ts`
- `feature/profile/hooks/use-refresh-user-display.ts` (新規)
- `feature/profile/hooks/use-update-profile-name.ts` / `use-update-profile-handle.ts` / `use-update-profile-picture.ts` (新規)
- `feature/profile/components/profile-view.tsx`: 3 更新フックを feature facade 経由に切り替え

## テスト計画

- [x] `bun run check-types`
- [x] `bun run lint`
- [x] `bun run test`（unit 144件 pass。再取得キーの決定 4件を追加）
- [x] `bun run test:storybook --run`（play 73件 pass）
- [ ] 実 Clerk での反映確認（dev は `AUTH_MOCKING` でモック no-op のため stg で確認予定）

## 補足

- **画像の即時反映はご依頼(表示名)を超えた追加対応**です。表示名・@ハンドルと同じ payload・同じ表示箇所（`pd-author` はアバター＋表示名＋@ハンドルを一緒に描画）のため、片方だけ即時反映すると不整合になることから併せて対応しました。不要なら画像分は落とせます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)