### PR TITLE
fix: ID 変更で本人確認が要求されたとき再認証フローを通す

### DIFF
--- a/apps/frontend/src/feature/profile/components/profile-handle-field.stories.tsx
+++ b/apps/frontend/src/feature/profile/components/profile-handle-field.stories.tsx
@@ -88,6 +88,25 @@ export const InvalidCharacterShowsAlert: Story = {
   },
 };
 
+export const ReverificationCancelledShowsNeutralNotice: Story = {
+  name: "本人確認をキャンセルすると変更していないことを穏当に伝える",
+  args: {
+    onSubmit: () => Promise.resolve({ ok: false, reason: "cancelled" }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("button", { name: "保存する" }));
+
+    await waitFor(() =>
+      expect(inlineStatusText(canvasElement)).toBe(
+        "本人確認が完了しなかったため、IDは変更していません",
+      ),
+    );
+    expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+  },
+};
+
 export const UpdateFailureShowsAlert: Story = {
   name: "保存に失敗すると再試行を促す Alert を出す",
   args: {

--- a/apps/frontend/src/feature/profile/components/profile-handle-field.tsx
+++ b/apps/frontend/src/feature/profile/components/profile-handle-field.tsx
@@ -28,12 +28,17 @@ interface ProfileHandleFieldProps {
   onSubmit: (handle: string) => Promise<UpdateProfileHandleResult>;
 }
 
+type HandleErrorReason = Exclude<UpdateProfileHandleFailureReason, "cancelled">;
+
 type Feedback =
   | { status: "idle" }
   | { status: "success" }
-  | { status: "error"; reason: UpdateProfileHandleFailureReason };
+  | { status: "cancelled" }
+  | { status: "error"; reason: HandleErrorReason };
 
-const ALERT_MESSAGE: Record<UpdateProfileHandleFailureReason, string> = {
+const CANCELLED_MESSAGE = "本人確認が完了しなかったため、IDは変更していません";
+
+const ALERT_MESSAGE: Record<HandleErrorReason, string> = {
   taken: "このIDは既に使われています。別のIDを入力してください。",
   invalidLength: "IDの文字数が規定に合っていません。別のIDを入力してください。",
   invalidCharacter:
@@ -43,7 +48,7 @@ const ALERT_MESSAGE: Record<UpdateProfileHandleFailureReason, string> = {
   unknown: "IDの変更に失敗しました。時間をおいて再試行してください。",
 };
 
-const TOAST_MESSAGE: Record<UpdateProfileHandleFailureReason, string> = {
+const TOAST_MESSAGE: Record<HandleErrorReason, string> = {
   taken: "このIDは既に使われています",
   invalidLength: "IDの文字数が規定に合っていません",
   invalidCharacter: "IDに使えない文字が含まれています",
@@ -69,6 +74,11 @@ export function ProfileHandleField({
       if (result.ok) {
         setFeedback({ status: "success" });
         toast.success("IDを変更しました");
+        return;
+      }
+      if (result.reason === "cancelled") {
+        setFeedback({ status: "cancelled" });
+        toast.message(CANCELLED_MESSAGE);
         return;
       }
       setFeedback({ status: "error", reason: result.reason });
@@ -122,6 +132,7 @@ export function ProfileHandleField({
           role="status"
         >
           {feedback.status === "success" && "IDを変更しました"}
+          {feedback.status === "cancelled" && CANCELLED_MESSAGE}
         </p>
 
         <div className="flex justify-end">

--- a/apps/frontend/src/lib/auth/profile-handle-failure.ts
+++ b/apps/frontend/src/lib/auth/profile-handle-failure.ts
@@ -3,6 +3,7 @@ export type UpdateProfileHandleFailureReason =
   | "invalidLength"
   | "invalidCharacter"
   | "needsNonNumberChar"
+  | "cancelled"
   | "unknown";
 
 const REASON_BY_CLERK_CODE: Record<string, UpdateProfileHandleFailureReason> = {

--- a/apps/frontend/src/lib/auth/use-update-profile.ts
+++ b/apps/frontend/src/lib/auth/use-update-profile.ts
@@ -1,7 +1,10 @@
 "use client";
 
-import { useUser as useClerkUser } from "@clerk/nextjs";
-import { isClerkAPIResponseError } from "@clerk/nextjs/errors";
+import { useUser as useClerkUser, useReverification } from "@clerk/nextjs";
+import {
+  isClerkAPIResponseError,
+  isReverificationCancelledError,
+} from "@clerk/nextjs/errors";
 import { AUTH_MOCKING } from "./mocking";
 import {
   clerkCodesToHandleFailureReason,
@@ -82,15 +85,24 @@ const useMockUpdateProfileHandle = (): UpdateProfileHandle => ({
 
 const useClerkUpdateProfileHandle = (): UpdateProfileHandle => {
   const { user } = useClerkUser();
+  const updateUsername = useReverification((username: string) => {
+    if (!user) {
+      throw new Error("ユーザーが見つかりません");
+    }
+    return user.update({ username });
+  });
   return {
     updateProfileHandle: async (handle) => {
       if (!user) {
         return { ok: false, reason: "unknown" };
       }
       try {
-        await user.update({ username: handle });
+        await updateUsername(handle);
         return { ok: true };
       } catch (error) {
+        if (isReverificationCancelledError(error)) {
+          return { ok: false, reason: "cancelled" };
+        }
         return { ok: false, reason: toHandleFailureReason(error) };
       }
     },


### PR DESCRIPTION
## 背景

実機（本番 Clerk）で ID(@handle) を変更しようとすると、次のエラーで弾かれていた:

```
{ code: "session_reverification_required",
  message: "Reverification required",
  long_message: "You need to provide additional verification to perform this operation" }
```

Clerk のインスタンス設定で username 変更が「本人確認（reverification）が必要な機微操作」に指定されているため、`user.update({ username })` が再認証を要求している。

現状の実装はこのコードを `unknown` に落として **「IDの変更に失敗しました。時間をおいて再試行してください。」**と誤案内していた。再試行しても永久に本人確認は挟まらないので、ユーザーは ID を変更できない。

## 何を直すか

Clerk の `useReverification` フックで username 更新をラップする。本人確認が要求されたら Clerk のプレビルト UI（パスワード / 2FA の再入力）が表示され、**成功後に元の更新を自動リトライ**する。

ユーザーが本人確認モーダルをキャンセルした場合は `isReverificationCancelledError` で判定し、`cancelled` として扱う。これは**エラーではなくユーザー自身の中断**なので、破壊的な Alert は出さず、中立の文言で「変更していない」ことを穏当に伝える（success と同じ status 行 + `toast.message`）。

## 変更ファイル

- `lib/auth/use-update-profile.ts`: `useUpdateProfileHandle`（Clerk 実装）を `useReverification` でラップ。cancel は `isReverificationCancelledError` で `cancelled` に翻訳
- `lib/auth/profile-handle-failure.ts`: 失敗理由の union に `cancelled` を追加
- `feature/profile/components/profile-handle-field.tsx`: `cancelled` を破壊的 Alert ではなく中立フィードバックで表示（エラー用文言マップは `cancelled` を除外した型に）
- `feature/profile/components/profile-handle-field.stories.tsx`: 本人確認キャンセル時に Alert を出さず中立文言を出す play を追加

## テスト計画

- [x] `bun run check-types`
- [x] `bun run lint`
- [x] `bun run test`（unit 144件 pass）
- [x] `bun run test:storybook --run`（play 74件 pass。キャンセル時に `role="alert"` を出さないことを検証）
- [ ] **実 Clerk での再認証フロー確認**（プレビルト UI はローカル/Storybook では再現不可のため実機で要確認。ID 変更 → 本人確認モーダル表示 → 認証成功で変更反映、キャンセルで中立文言、を実機で確認してほしい）

## 補足

- 本人確認が要求されるのは Clerk 設定で保護対象になっている操作のみ。今回観測されたのは username。表示名・画像も同様に保護対象化されている場合は同じラップが必要になるが、現時点では未対応（観測されていない）。必要になれば同じ `useReverification` パターンで対応可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)