### PR TITLE
fix: PD 詳細画面で親 PD のいいねを楽観的に反映する

### DIFF
--- a/apps/frontend/src/feature/pd/api/query-keys.test.ts
+++ b/apps/frontend/src/feature/pd/api/query-keys.test.ts
@@ -1,7 +1,9 @@
 import { hashKey } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 import {
+  isPdDetailQueryKey,
   pdDetailQueryKey,
+  pdRootQueryKey,
   rePdDetailQueryKey,
   weeklyStatsQueryKey,
 } from "./query-keys";
@@ -41,5 +43,22 @@ describe("rePdDetailQueryKey", () => {
 describe("weeklyStatsQueryKey", () => {
   it("週次統計エンドポイントのキーを返す", () => {
     expect(weeklyStatsQueryKey()).toEqual(["/pd/stats/weekly"]);
+  });
+});
+
+describe("isPdDetailQueryKey", () => {
+  it("ホーム・プロフィール・詳細の PD 一覧キーはいいね更新の対象になる", () => {
+    expect(isPdDetailQueryKey(pdDetailQueryKey())).toBe(true);
+    expect(isPdDetailQueryKey(pdDetailQueryKey({ userName: "me" }))).toBe(true);
+    expect(isPdDetailQueryKey(pdDetailQueryKey({ pdId: "p1" }))).toBe(true);
+  });
+
+  it("RePD 一覧キーは詳細マーカーが同じでもいいね更新の対象にしない", () => {
+    expect(isPdDetailQueryKey(rePdDetailQueryKey("p1"))).toBe(false);
+  });
+
+  it("詳細マーカーの無い PD ルート・週次統計キーはいいね更新の対象にしない", () => {
+    expect(isPdDetailQueryKey(pdRootQueryKey())).toBe(false);
+    expect(isPdDetailQueryKey(weeklyStatsQueryKey())).toBe(false);
   });
 });

--- a/apps/frontend/src/feature/pd/api/query-keys.ts
+++ b/apps/frontend/src/feature/pd/api/query-keys.ts
@@ -1,3 +1,4 @@
+import type { QueryKey } from "@tanstack/react-query";
 import {
   getFetchPdsQueryKey,
   getFetchRePdsQueryKey,
@@ -6,9 +7,14 @@ import {
 
 const DETAIL = "詳細";
 
+const [PD_ROOT] = getFetchPdsQueryKey();
+
 export const pdDetailQueryKey = (
   params: { pdId?: string; userName?: string } = {},
 ) => [...getFetchPdsQueryKey(params), DETAIL] as const;
+
+export const isPdDetailQueryKey = (queryKey: QueryKey): boolean =>
+  queryKey[0] === PD_ROOT && queryKey[queryKey.length - 1] === DETAIL;
 
 export const pdRootQueryKey = () => getFetchPdsQueryKey();
 

--- a/apps/frontend/src/feature/pd/utils/optimistic-update-like.test.ts
+++ b/apps/frontend/src/feature/pd/utils/optimistic-update-like.test.ts
@@ -68,7 +68,6 @@ describe("optimisticUpdateLike", () => {
 
     await optimisticUpdateLike({
       pd,
-      queryKey,
       queryClient,
       myUserId: "me",
       myLikeUser: me,
@@ -98,7 +97,6 @@ describe("optimisticUpdateLike", () => {
 
     await optimisticUpdateLike({
       pd,
-      queryKey,
       queryClient,
       myUserId: "me",
       myLikeUser: me,

--- a/apps/frontend/src/feature/pd/utils/optimistic-update-like.ts
+++ b/apps/frontend/src/feature/pd/utils/optimistic-update-like.ts
@@ -3,6 +3,7 @@ import type {
   QueryClient,
   QueryKey,
 } from "@tanstack/react-query";
+import { isPdDetailQueryKey } from "../api/query-keys";
 import type { LikeUser, Pd } from "../types";
 
 type InfinitePds = {
@@ -10,56 +11,75 @@ type InfinitePds = {
   nextCursor?: string;
 };
 
+export type PdDetailSnapshot = Array<
+  [QueryKey, InfiniteData<InfinitePds> | undefined]
+>;
+
+const togglePdLike = ({
+  page,
+  pd,
+  myUserId,
+  myLikeUser,
+}: {
+  page: InfinitePds;
+  pd: Pd;
+  myUserId: string;
+  myLikeUser: LikeUser;
+}): InfinitePds => ({
+  ...page,
+  items: page.items.map((oldPd) => {
+    if (oldPd.id !== pd.id) return oldPd;
+
+    const isCurrentlyLiked = oldPd.likes.some(
+      (like) => like.userId === myUserId,
+    );
+    const updatedLikes = isCurrentlyLiked
+      ? oldPd.likes.filter((like) => like.userId !== myUserId)
+      : [...oldPd.likes, { userId: myUserId }];
+    const updatedLikeUsers = isCurrentlyLiked
+      ? oldPd.likeUsers.filter((user) => user.userId !== myUserId)
+      : [...oldPd.likeUsers, myLikeUser];
+
+    return {
+      ...oldPd,
+      likes: updatedLikes,
+      likeUsers: updatedLikeUsers,
+      likeCount: isCurrentlyLiked
+        ? Number(oldPd.likeCount) - 1
+        : Number(oldPd.likeCount) + 1,
+    };
+  }),
+});
+
 export const optimisticUpdateLike = async ({
   pd,
-  queryKey,
   queryClient,
   myUserId,
   myLikeUser,
 }: {
   pd: Pd;
-  queryKey: QueryKey;
   queryClient: QueryClient;
   myUserId: string;
   myLikeUser: LikeUser;
-}) => {
-  const previousPages =
-    queryClient.getQueryData<InfiniteData<InfinitePds>>(queryKey);
+}): Promise<{ previousQueries: PdDetailSnapshot }> => {
+  const filters = {
+    predicate: ({ queryKey }: { queryKey: QueryKey }) =>
+      isPdDetailQueryKey(queryKey),
+  } as const;
 
-  queryClient.setQueryData<InfiniteData<InfinitePds>>(queryKey, (oldPages) => {
+  const previousQueries =
+    queryClient.getQueriesData<InfiniteData<InfinitePds>>(filters);
+
+  queryClient.setQueriesData<InfiniteData<InfinitePds>>(filters, (oldPages) => {
     if (!oldPages) return oldPages;
 
     return {
       ...oldPages,
-      pages: oldPages.pages.map((oldPage) => {
-        return {
-          ...oldPage,
-          items: oldPage.items.map((oldPd) => {
-            if (oldPd.id !== pd.id) return oldPd;
-
-            const isCurrentlyLiked = oldPd.likes.some(
-              (like) => like.userId === myUserId,
-            );
-            const updatedLikes = isCurrentlyLiked
-              ? oldPd.likes.filter((like) => like.userId !== myUserId)
-              : [...oldPd.likes, { userId: myUserId }];
-            const updatedLikeUsers = isCurrentlyLiked
-              ? oldPd.likeUsers.filter((user) => user.userId !== myUserId)
-              : [...oldPd.likeUsers, myLikeUser];
-
-            return {
-              ...oldPd,
-              likes: updatedLikes,
-              likeUsers: updatedLikeUsers,
-              likeCount: isCurrentlyLiked
-                ? Number(oldPd.likeCount) - 1
-                : Number(oldPd.likeCount) + 1,
-            };
-          }),
-        };
-      }),
+      pages: oldPages.pages.map((oldPage) =>
+        togglePdLike({ page: oldPage, pd, myUserId, myLikeUser }),
+      ),
     };
   });
 
-  return { previousPages };
+  return { previousQueries };
 };

--- a/apps/frontend/src/feature/pd/utils/pd-like-mutation-options.test.ts
+++ b/apps/frontend/src/feature/pd/utils/pd-like-mutation-options.test.ts
@@ -9,8 +9,12 @@ import { pdDetailQueryKey } from "../api/query-keys";
 import type { LikeUser, Pd } from "../types";
 import { createPdLikeMutationOptions } from "./pd-like-mutation-options";
 
+const mutateControl = vi.hoisted(() => ({ shouldFail: false }));
+
 vi.mock("@/feature/pd/api/pd/mutate-pd-like", () => ({
-  mutatePdLike: async () => undefined,
+  mutatePdLike: async () => {
+    if (mutateControl.shouldFail) throw new Error("いいねに失敗");
+  },
 }));
 vi.mock("@/utils/legacy-delay", () => ({ legacyDelay: async () => undefined }));
 vi.mock("sonner", () => ({ toast: { warning: () => undefined } }));
@@ -78,6 +82,7 @@ const makeFetchThatCollapsesPagesOnRefetch = () => {
 let queryClient: QueryClient;
 
 beforeEach(() => {
+  mutateControl.shouldFail = false;
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -110,7 +115,6 @@ const likePd = async (pd: Pd) => {
     queryClient,
     createPdLikeMutationOptions({
       pd,
-      queryKey,
       queryClient,
       myUserId: "me",
       myLikeUser: me,
@@ -166,5 +170,53 @@ describe("いいねと無限スクロールで蓄積したページ", () => {
     expect(updated.likeCount).toBe(1);
 
     unsubscribe();
+  });
+});
+
+describe("PD 詳細画面で親 PD にいいねしたとき", () => {
+  const detailKey = pdDetailQueryKey({ pdId: "pd-0" });
+  const timelineKey = pdDetailQueryKey();
+
+  const seedOnePage = (key: readonly unknown[], pd: Pd) => {
+    queryClient.setQueryData<InfiniteData<InfinitePds>>(key, {
+      pages: [{ items: [pd], nextCursor: undefined }],
+      pageParams: [undefined],
+    });
+  };
+
+  const pdIn = (key: readonly unknown[]) =>
+    queryClient.getQueryData<InfiniteData<InfinitePds>>(key)?.pages[0]
+      .items[0] as Pd;
+
+  test("詳細画面の親 PD に自分のいいねが楽観的に反映され件数が増える", async () => {
+    seedOnePage(detailKey, aPd("pd-0"));
+
+    await likePd(aPd("pd-0"));
+
+    expect(pdIn(detailKey).likes).toContainEqual({ userId: "me" });
+    expect(pdIn(detailKey).likeCount).toBe(1);
+  });
+
+  test("同じ PD がタイムラインと詳細の両方にあるとき一度のいいねで両方に反映される", async () => {
+    seedOnePage(timelineKey, aPd("pd-0"));
+    seedOnePage(detailKey, aPd("pd-0"));
+
+    await likePd(aPd("pd-0"));
+
+    expect(pdIn(timelineKey).likeCount).toBe(1);
+    expect(pdIn(detailKey).likeCount).toBe(1);
+  });
+
+  test("いいねに失敗すると全画面のいいねが元の状態に巻き戻る", async () => {
+    seedOnePage(timelineKey, aPd("pd-0"));
+    seedOnePage(detailKey, aPd("pd-0"));
+    mutateControl.shouldFail = true;
+
+    await likePd(aPd("pd-0")).catch(() => undefined);
+
+    expect(pdIn(timelineKey).likes).not.toContainEqual({ userId: "me" });
+    expect(pdIn(timelineKey).likeCount).toBe(0);
+    expect(pdIn(detailKey).likes).not.toContainEqual({ userId: "me" });
+    expect(pdIn(detailKey).likeCount).toBe(0);
   });
 });

--- a/apps/frontend/src/feature/pd/utils/pd-like-mutation-options.ts
+++ b/apps/frontend/src/feature/pd/utils/pd-like-mutation-options.ts
@@ -1,28 +1,20 @@
-import type {
-  InfiniteData,
-  QueryClient,
-  QueryKey,
-  UseMutationOptions,
-} from "@tanstack/react-query";
+import type { QueryClient, UseMutationOptions } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { mutatePdLike } from "@/feature/pd/api/pd/mutate-pd-like";
 import { errorDisplay } from "@/lib/error-message";
 import { legacyDelay } from "@/utils/legacy-delay";
 import type { LikeUser, Pd } from "../types";
-import { optimisticUpdateLike } from "./optimistic-update-like";
-
-type InfinitePds = {
-  items: Pd[];
-  nextCursor?: string;
-};
+import {
+  optimisticUpdateLike,
+  type PdDetailSnapshot,
+} from "./optimistic-update-like";
 
 type PdLikeMutationContext = {
-  previousPages?: InfiniteData<InfinitePds>;
+  previousQueries?: PdDetailSnapshot;
 };
 
 interface CreatePdLikeMutationOptionsInput {
   pd: Pd;
-  queryKey: QueryKey;
   queryClient: QueryClient;
   myUserId: string;
   myLikeUser: LikeUser;
@@ -30,7 +22,6 @@ interface CreatePdLikeMutationOptionsInput {
 
 export const createPdLikeMutationOptions = ({
   pd,
-  queryKey,
   queryClient,
   myUserId,
   myLikeUser,
@@ -45,10 +36,10 @@ export const createPdLikeMutationOptions = ({
     await mutatePdLike(pd.id);
   },
   onMutate: () =>
-    optimisticUpdateLike({ pd, queryKey, queryClient, myUserId, myLikeUser }),
+    optimisticUpdateLike({ pd, queryClient, myUserId, myLikeUser }),
   onError: (error, _variables, context) => {
-    if (context?.previousPages) {
-      queryClient.setQueryData(queryKey, context.previousPages);
+    for (const [key, data] of context?.previousQueries ?? []) {
+      queryClient.setQueryData(key, data);
     }
     toast.warning(errorDisplay(error).message);
   },

--- a/apps/frontend/src/hooks/use-pd-like.ts
+++ b/apps/frontend/src/hooks/use-pd-like.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { pdDetailQueryKey } from "@/feature/pd/api/query-keys";
 import type { Pd } from "@/feature/pd/types";
 import { buildLikeUser } from "@/feature/pd/utils/build-like-user";
 import { createPdLikeMutationOptions } from "@/feature/pd/utils/pd-like-mutation-options";
@@ -13,12 +12,9 @@ export const usePdLike = ({ pd }: { pd: Pd }) => {
   const myUserId = user?.id ?? "";
   const myLikeUser = buildLikeUser(user);
 
-  const queryKey = pdDetailQueryKey();
-
   const { mutate: toggleLike, isPending } = useMutation(
     createPdLikeMutationOptions({
       pd,
-      queryKey,
       queryClient,
       myUserId,
       myLikeUser,


### PR DESCRIPTION
## 概要

PD 詳細画面（`/pd/[pdId]`）で親 PD にいいねしても楽観的更新が画面に反映されない不具合を修正する。API 自体は走っていたが UI が更新されなかった。

## 原因

`usePdLike` が楽観更新の書き込み先クエリキーを `pdDetailQueryKey()`（params 無し = `["/pd", {}, "詳細"]`）にハードコードしていた。

- **ホームタイムライン**: `usePd({ userName: undefined })` のキーは `["/pd", {pdId:undefined, userName:undefined}, "詳細"]`。React Query のハッシュ上 `["/pd", {}, "詳細"]` と一致する（undefined は JSON 化で消える）ため、**偶然**効いていた。
- **PD 詳細画面**: `usePd({ pdId })` のキーは `["/pd", {pdId:"xxx"}, "詳細"]`。ハードコードした空 params キーと一致せず、`setQueryData` が空キャッシュへ no-op 書き込みになり画面が更新されなかった。
- 同じ理由で**プロフィールタイムライン**（`usePd({ userName })`）も壊れていた。

共有コンポーネント（`PdCard` → `PdLikeButton` → `usePdLike`）は自分の描画文脈のクエリキーを知らないのが本質的な問題。

## 修正

単一キー狙い撃ちをやめ、`isPdDetailQueryKey` predicate（先頭 `/pd` + 末尾 `詳細`）で **PD 一覧系クエリすべて**（ホーム/プロフィール/詳細）を `setQueriesData` で一括更新する方式に変更した。

- `query-keys.ts`: `isPdDetailQueryKey` を追加（RePd `["/repd", ...]` や週次統計は先頭で除外）
- `optimistic-update-like.ts`: 単一 `queryKey` → predicate で全一致クエリを更新。ロールバック用に全スナップショット（`PdDetailSnapshot`）を返す
- `pd-like-mutation-options.ts` / `use-pd-like.ts`: `queryKey` 引数を撤去。`onError` は全スナップショットを復元
- 副次効果として、ホームでいいね→詳細へ遷移してもいいね状態が同期される

## テスト計画

- [x] `bun run check-types`（frontend）
- [x] `bun run lint`（biome, 変更分クリーン）
- [x] `bun run test`（unit 150 pass）
  - PD 詳細画面の親 PD いいねが楽観反映される（元バグの RED→GREEN）
  - 同一 PD がタイムラインと詳細の両方にあるとき一度のいいねで両方反映（`setQueriesData` の退行検出）
  - いいね失敗時に全画面のいいねが巻き戻る（`onError` ロールバック）
  - `isPdDetailQueryKey` の対象/非対象（RePd・週次統計を除外）
- [x] `bun run test:storybook --run`（74 pass）
- [x] React Doctor（no issues）
- [ ] dev サーバーでの実機動作確認（未実施）

## レビュー

`/code-review` を 2 ラウンド実施し収束（ESCALATE 0 件）。correctness / security / spec は全て empirical 検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)